### PR TITLE
Remove menu elements

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -66,12 +66,7 @@ main:
   name: Genomics
   url: "/lessons/#genomics"
   parent: lessons
-# Main Carpentries site
-- identifier: carpentries
-  name: The Carpentries
-  url: "https://carp-new-website.netlify.app/"
-  parent: null
-  weight: 40
+
 
 footer:
 # Footer menu: Menu 1

--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -72,11 +72,6 @@ main:
   url: "https://carp-new-website.netlify.app/"
   parent: null
   weight: 40
-- identifier: search
-  name: Search
-  url: /search/
-  parent: null
-  weight: 50
 
 footer:
 # Footer menu: Menu 1

--- a/content/search.md
+++ b/content/search.md
@@ -1,5 +1,0 @@
----
-title: "Search"
----
-
-{{< search >}}


### PR DESCRIPTION
- Remove "search" because the website content is not complex enough to need it
- Remove "The Carpentries" because it is in the top tabbed menu